### PR TITLE
Fix loggers options and level inheritance

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -88,7 +88,7 @@ class MonkLogger extends logLevel.constructor {
     let logger = _loggersByName[name]
     if (!logger) {
       logger = _loggersByName[name] = new MonkLogger(
-        name, level || this.level, {...this.options, ...options})
+        name, level || this.getLevel(), {...this.options, ...options})
     }
     return logger
   }

--- a/lib/log.js
+++ b/lib/log.js
@@ -76,17 +76,19 @@ class MonkLogger extends logLevel.constructor {
   /**
    *
    * @param {string} name - child logger name
-   * @param {string} level - only output log messages of at least this level
-   * @param {object} options - loglevel-plugin-prefix options
+   * @param {string} [level=null] - log level for the new logger. If null
+   *   (the default), inherits the parent's one.
+   * @param {object} [options={}] - loglevel-plugin-prefix options to apply
+   *   on top of parent ones.
    */
-  getLogger (name, level, options) {
+  getLogger (name, level = null, options = {}) {
     if (typeof name !== "string" || name === "") {
       throw new TypeError("You must supply a name when creating a logger.")
     }
     let logger = _loggersByName[name]
     if (!logger) {
       logger = _loggersByName[name] = new MonkLogger(
-        name, level, {...this.options, ...options})
+        name, level || this.level, {...this.options, ...options})
     }
     return logger
   }


### PR DESCRIPTION
Parent level was not propagated to child loggers, so this wouldn't log anything because `childLogger` would have level `WARN` (the default)

```js
const log = require('monk-log')
log.setDefaultLevel('INFO')
const childLogger = log.getLogger('child')
childLogger.info('hey!')
```

now child loggers correctly returns parent's INFO level and shows the log message.