### PR TITLE
RFC3339 default timestamp format

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const log = require('monk-log')
 log.warn('You can have nice log messages in just one line!')
 
 // Outputs
-// [2019-02-18T01:10:49.933] WARN [root]: You can have nice log messages in just one line!
+// [2019-02-18T01:10:49.933+01:00] WARN [root]: You can have nice log messages in just one line!
 ```
 
 ### Child loggers with custom format
@@ -73,8 +73,8 @@ childLogger.error('this is an error message')
 
 // Outputs
 // [2019-02-18T01:08:46.260] INFO [root]: Child logger has been set up
-// When: 2019-02-18T01:08:46.262, who: CHILD, why: DEBUG, what: this is a debug message
-// When: 2019-02-18T01:08:46.262, who: CHILD, why: INFO, what: This is a info message
-// When: 2019-02-18T01:08:46.262, who: CHILD, why: WARN, what: this is a warning message
-// When: 2019-02-18T01:08:46.263, who: CHILD, why: ERROR, what: this is an error message
+// When: 2019-02-18T01:08:46.262+01:00, who: CHILD, why: DEBUG, what: this is a debug message
+// When: 2019-02-18T01:08:46.262+01:00, who: CHILD, why: INFO, what: This is a info message
+// When: 2019-02-18T01:08:46.262+01:00, who: CHILD, why: WARN, what: this is a warning message
+// When: 2019-02-18T01:08:46.263+01:00, who: CHILD, why: ERROR, what: this is an error message
 ```

--- a/lib/log.js
+++ b/lib/log.js
@@ -12,11 +12,35 @@ const colors = Object.freeze({
   ERROR: chalk.red
 })
 
-const defaultTimestampFormatter = (date) => {
-  const tzOffset = date.getTimezoneOffset() * 60000 // offset in milliseconds
-  const localISOTime = (new Date(date - tzOffset)).toISOString().slice(0, -1) // => '2015-01-26T06:40:36.181'
-  return localISOTime
+/**
+ * Converts a date to the RFC3339 profile of the ISO 8601 standard
+ *
+ * Example: 2019-02-08T19:02:09.432+01:00
+ * https://tools.ietf.org/html/rfc3339#section-5.6
+ *
+ * Inspired by https://stackoverflow.com/a/17415677/1362167
+ */
+const dateToISOString = (d) => {
+  // Pad an integer >=0, <= 99 to 2 digits.
+  // Useful to pad days, minutes, hours, months etc.
+  const pad2 = num => `${num < 10 ? '0' : ''}${num}`
+  const pad3 = num => `${num < 100 ? (num < 10 ? '00' : '0') : ''}${num}`
+  const offset = -d.getTimezoneOffset()
+  const absOffset = Math.abs(offset)
+  return ''
+    + d.getFullYear()
+    + '-' + pad2(d.getMonth() + 1)
+    + '-' + pad2(d.getDate())
+    + 'T' + pad2(d.getHours())
+    + ':' + pad2(d.getMinutes())
+    + ':' + pad2(d.getSeconds())
+    + '.' + pad3(d.getMilliseconds())
+    + (offset >= 0 ? '+' : '-')
+    + pad2(Math.floor(absOffset / 60))
+    + ':' + pad2(absOffset % 60)
 }
+
+const defaultTimestampFormatter = dateToISOString
 
 const defaultNameFormatter = (name) => {
   return chalk.green(name)

--- a/lib/log.js
+++ b/lib/log.js
@@ -20,21 +20,20 @@ const colors = Object.freeze({
  *
  * Inspired by https://stackoverflow.com/a/17415677/1362167
  */
-const dateToISOString = (d) => {
+const dateToISOString = (d, milliseconds = true) => {
   // Pad an integer >=0, <= 99 to 2 digits.
   // Useful to pad days, minutes, hours, months etc.
   const pad2 = num => `${num < 10 ? '0' : ''}${num}`
   const pad3 = num => `${num < 100 ? (num < 10 ? '00' : '0') : ''}${num}`
   const offset = -d.getTimezoneOffset()
   const absOffset = Math.abs(offset)
-  return ''
-    + d.getFullYear()
+  return d.getFullYear()
     + '-' + pad2(d.getMonth() + 1)
     + '-' + pad2(d.getDate())
     + 'T' + pad2(d.getHours())
     + ':' + pad2(d.getMinutes())
     + ':' + pad2(d.getSeconds())
-    + '.' + pad3(d.getMilliseconds())
+    + (milliseconds ? ('.' + pad3(d.getMilliseconds())) : '')
     + (offset >= 0 ? '+' : '-')
     + pad2(Math.floor(absOffset / 60))
     + ':' + pad2(absOffset % 60)
@@ -123,3 +122,6 @@ defaultLogger.getLoggers = () => _loggersByName
 // Export default logger. Can be used directly, or can be used
 // to obtain child loggers.
 module.exports = defaultLogger
+// Export dateToISOString, users may want to use it to define a custom
+// timestampformatter
+module.exports.dateToISOString = dateToISOString


### PR DESCRIPTION
Ha richiesto più tempo del previsto, maledetta standard library scrausa.

Ora però defaulta a logs che davvero indicano un instante:

```
[2019-03-01T21:09:15.513+01:00] WARN [root]: warn
[2019-03-01T21:09:15.517+01:00] ERROR [root]: error
```

https://tools.ietf.org/html/rfc3339